### PR TITLE
Fix allowed character rule evaluate method

### DIFF
--- a/Navajo/NJOPasswordStrengthEvaluator.h
+++ b/Navajo/NJOPasswordStrengthEvaluator.h
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 @import Foundation;
+@import CoreGraphics;
 @import Darwin.Availability;
 
 /**

--- a/Navajo/NJOPasswordStrengthEvaluator.m
+++ b/Navajo/NJOPasswordStrengthEvaluator.m
@@ -184,7 +184,7 @@ static inline __attribute__((const)) NJOPasswordStrength NJOPasswordStrengthForE
 #pragma mark - NJOPasswordRule
 
 - (BOOL)evaluateWithString:(NSString *)string {
-    return [string rangeOfCharacterFromSet:self.disallowedCharacters].location == NSNotFound;
+    return [string rangeOfCharacterFromSet:self.disallowedCharacters].location != NSNotFound;
 }
 
 - (NSString *)localizedErrorDescription {


### PR DESCRIPTION
The original method return a revered value.
